### PR TITLE
chore(travis): update C++ compiler for travisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,3 @@ after_success:
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
-    - /^v\d+\.\d+\.\d+$

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,12 @@ node_js:
   - '7'
   - '6'
   - '4'
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-4.8
-    - g++-4.8  
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get -qq update
+  - sudo apt-get -qq install g++-4.8
+env:
+  - CXX=g++-4.8
 before_script:
   - npm prune
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ node_js:
   - '7'
   - '6'
   - '4'
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8  
 before_script:
   - npm prune
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ after_success:
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
+    - /^v\d+\.\d+\.\d+$

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
   },
   "scripts": {
     "test": "standard && node test.js",
-    "prepublish": "semantic-release pre",
-    "postpublish": "semantic-release post",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "files": [


### PR DESCRIPTION
TravisCI builds failing when running `node-gyp rebuild` for lwip due to lwip requiring gcc 4.8+. This change updates gcc on the CI server before executing the build.